### PR TITLE
Fix duplicate lint checks

### DIFF
--- a/.github/workflows/ts-standard-lint.yml
+++ b/.github/workflows/ts-standard-lint.yml
@@ -2,6 +2,7 @@ name: ts-standard
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
Right now the lint check runs twice on each pull request because it satisfies both the push and pull_request triggers. This PR changes the push trigger to only watch the main branch.