### PR TITLE
Imagetools wrapper component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Route, Switch, Link } from 'wouter'
 import classes from './App.module.scss'
 import Elira from './pages/Elira'
 import Finana from './pages/Finana'
+import ImageExample from './pages/ImageExample'
 import Pomu from './pages/Pomu'
 
 export default function App (): JSX.Element {
@@ -30,6 +31,7 @@ export default function App (): JSX.Element {
         </Route>
         <Route>
           <div>Whomst?</div>
+          <ImageExample />
         </Route>
       </Switch>
     </div>

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -1,6 +1,7 @@
 interface ImageToolProps {
   src: metadata[] | string
   className?: string
+  alt?: string
   width?: string
   height?: string
 }
@@ -8,7 +9,7 @@ interface ImageToolProps {
 export default function Image (props: ImageToolProps): JSX.Element {
   if (typeof props.src === 'string') {
     return (
-      <img src={props.src} width={props.width} height={props.height} />
+      <img src={props.src} width={props.width} height={props.height} alt={props.alt} />
     )
   } else {
     const [fallback, ...sources] = props.src
@@ -25,6 +26,7 @@ export default function Image (props: ImageToolProps): JSX.Element {
           src={fallback.src}
           width={props.width}
           height={props.height}
+          alt={props.alt}
         />
       </picture>
     )

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -1,0 +1,32 @@
+interface ImageToolProps {
+  src: metadata[] | string
+  className?: string
+  width?: string
+  height?: string
+}
+
+export default function Image (props: ImageToolProps): JSX.Element {
+  if (typeof props.src === 'string') {
+    return (
+      <img src={props.src} width={props.width} height={props.height} />
+    )
+  } else {
+    const [fallback, ...sources] = props.src
+    return (
+      <picture className={props.className}>
+        {sources.map((metadata) => (
+          <source
+            key={metadata.src}
+            type={`image/${metadata.format}`}
+            srcSet={metadata.src}
+          />
+        ))}
+        <img
+          src={fallback.src}
+          width={props.width}
+          height={props.height}
+        />
+      </picture>
+    )
+  }
+}

--- a/src/components/TalentLayout.tsx
+++ b/src/components/TalentLayout.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import './TalentLayout.scss'
+import Image from './Image'
 
 // TODO(abuffseagull) 2022-03-17: need to remove this
 // Probably just generate some random ids on the messages at load time
@@ -22,7 +23,7 @@ interface Props {
   name: string
   messages: Message[]
   fanarts: Fanart[]
-  portrait: string
+  portrait: string | metadata[]
   quote: string
   info: string
   youtube: string
@@ -59,7 +60,7 @@ function TalentLayout (props: Props): JSX.Element {
     <div className='talent-layout-container'>
       <div className='talent-profile-container'>
         <div className='talent-picture-box'>
-          <img src={props.portrait} />
+          <Image src={props.portrait} />
           <div className='talent-quote'>
             <span>{props.quote}</span>
           </div>
@@ -117,7 +118,7 @@ function TalentLayout (props: Props): JSX.Element {
                     {fanart.name} ({fanart.twitter})
                   </h4>
                   <p>{fanart.text}</p>
-                  <img src={fanart.artUrl} alt='' />
+                  <Image src={fanart.artUrl} alt='' />
                 </div>
               ))}
             </div>

--- a/src/images.d.ts
+++ b/src/images.d.ts
@@ -1,3 +1,10 @@
+interface metadata {
+  src: string
+  width: number
+  height: number
+  format: string
+}
+
 declare module '*&imagetools' {
   const urls: string[]
   export default urls
@@ -7,11 +14,6 @@ declare module '*&imagetools&single' {
   export default url
 }
 declare module '*&imagetools&meta' {
-  const metadata: Array<{
-    src: string
-    width: number
-    height: number
-    format: string
-  }>
+  const metadata: metadata[]
   export default metadata
 }

--- a/src/pages/Elira.tsx
+++ b/src/pages/Elira.tsx
@@ -1,5 +1,5 @@
 import TalentLayout from '../components/TalentLayout'
-import EliraImage from '../assets/liver-image/elira-placeholder.png'
+import EliraImage from '../assets/liver-image/elira-placeholder.png?format=png;avif;webp&imagetools&meta'
 
 export default function Elira (): JSX.Element {
   const name = 'Elira Pendora'

--- a/src/pages/Elira.tsx
+++ b/src/pages/Elira.tsx
@@ -1,45 +1,12 @@
-// TODO(abuffseagull) 2022-03-17: probably move this to a README
-/* eslint-disable no-unused-vars, @typescript-eslint/no-unused-vars */
-/*
- * So, imagetools.
- * Normally, when you import an image, it'll just give you a url as a string.
- */
-import normal from '../sheesh-pog-based.png'
-/*
- * You can just run the image through no problem just by specifying a format
- * as a query parameter to get some good compression
- */
-// @ts-expect-error: <- we'll fix this in a second
-import compressed from '../sheesh-pog-based.png?format=webp'
-/*
- * You can also specify multiple formats, which will return an array of strings.
- */
-// @ts-expect-error: hold on we'll get to it
-import multipleUrls from '../sheesh-pog-based.png?format=avif;webp;png'
-/*
- * Now the really cool thing is that there's a `metadata` query param that will return
- * extra info about each picture. Check the `images.d.ts` file for what it returns.
- */
-// @ts-expect-error: almost there
-import multipleData from '../sheesh-pog-based.png?format=avif;webp;png&meta'
-/*
- * Okay, to make typescript happy, you need to add `&imagetools` to the *end* of the url
- * (but before meta, check the images.d.ts for how it finds the files).
- * The actual imagetools plugin will ignore any query params it doesn't recognize, so
- * we're abusing it to pattern match on typescript
- * Also note the order of the formats. Fallback first, then in order of efficacy.
- */
-import sheeshPogBased from '../sheesh-pog-based.png?format=png;avif;webp&imagetools&meta'
 import TalentLayout from '../components/TalentLayout'
 import EliraImage from '../assets/liver-image/elira-placeholder.png'
-// The order is literally just to make this destructing easier, honestly
-const [fallback, ...sources] = sheeshPogBased
 
 export default function Elira (): JSX.Element {
   const name = 'Elira Pendora'
   const quote = 'Sheee-eeesh!'
   const info = 'Placeholder info for Elira!'
-  const youtubeLink = 'https://www.youtube.com/channel/UCIeSUTOTkF9Hs7q3SGcO-Ow'
+  const youtubeLink =
+		'https://www.youtube.com/channel/UCIeSUTOTkF9Hs7q3SGcO-Ow'
   const twitterLink = 'https://twitter.com/EliraPendora'
   const fanDiscordLink = ''
   const messages = [
@@ -94,55 +61,64 @@ export default function Elira (): JSX.Element {
       name: 'Vtuber Fan #1',
       twitter: '@vtuberfan#1',
       text: 'Lorem ipsum dolor sit amet consectetur adipisicing elit. Ratione molestias consequuntur minima odit pariatur veritatis, recusandae, nam esse velit maxime et tempore voluptatum? Voluptatibus, veritatis? Tenetur odit commodi sapiente obcaecati.',
-      artUrl: 'https://www.sciencenewsforstudents.org/wp-content/uploads/2020/04/1030_LL_trees-1028x579.png'
+      artUrl:
+				'https://www.sciencenewsforstudents.org/wp-content/uploads/2020/04/1030_LL_trees-1028x579.png'
     },
     {
       name: 'Vtuber Fan #2',
       twitter: '@vtuberfan#2',
       text: 'Congrats! Big Fan!!!!',
-      artUrl: 'https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/Ash_Tree_-_geograph.org.uk_-_590710.jpg/220px-Ash_Tree_-_geograph.org.uk_-_590710.jpg'
+      artUrl:
+				'https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/Ash_Tree_-_geograph.org.uk_-_590710.jpg/220px-Ash_Tree_-_geograph.org.uk_-_590710.jpg'
     },
     {
       name: 'Vtuber Fan #3342',
       twitter: '@vtuberfan#3342',
       text: 'Congrats! Big Fan!!!!',
-      artUrl: 'https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/Larix_decidua_Aletschwald.jpg/220px-Larix_decidua_Aletschwald.jpg'
+      artUrl:
+				'https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/Larix_decidua_Aletschwald.jpg/220px-Larix_decidua_Aletschwald.jpg'
     },
     {
       name: 'Vtuber Fan #4',
       twitter: '@vtuberfan#4',
       text: 'Congrats! Big Fan!!!!',
-      artUrl: 'https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/Daintree_Rainforest_4.jpg/170px-Daintree_Rainforest_4.jpg'
+      artUrl:
+				'https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/Daintree_Rainforest_4.jpg/170px-Daintree_Rainforest_4.jpg'
     },
     {
       name: 'Vtuber Fan #543',
       twitter: '@vtuberfan#543',
       text: 'Congrats! Big Fan!!!!',
-      artUrl: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/07/WisconsinScenery.jpg/220px-WisconsinScenery.jpg'
+      artUrl:
+				'https://upload.wikimedia.org/wikipedia/commons/thumb/0/07/WisconsinScenery.jpg/220px-WisconsinScenery.jpg'
     },
     {
       name: 'Vtuber Fan #333',
       twitter: '@vtuberfan#333',
       text: 'Lorem ipsum dolor sit amet consectetur adipisicing elit. Ratione molestias consequuntur minima odit pariatur veritatis, recusandae, nam esse velit maxime et tempiente obcaecati.',
-      artUrl: 'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7b/Bombax_LalBagh.JPG/220px-Bombax_LalBagh.JPG'
+      artUrl:
+				'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7b/Bombax_LalBagh.JPG/220px-Bombax_LalBagh.JPG'
     },
     {
       name: 'Vtuber Fan #9879',
       twitter: '@vtuberfan#9879',
       text: 'Congrats! Big Fan!!!!',
-      artUrl: 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/Buk1.JPG/170px-Buk1.JPG'
+      artUrl:
+				'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/Buk1.JPG/170px-Buk1.JPG'
     },
     {
       name: 'Vtuber Fan #56566',
       twitter: '@vtuberfan#56566',
       text: 'atione molestias consequuntur minima odit pariatur veritatis, recusandae, nam esse velit maxime et tempore voluptatum? Voluptatibus, veritatis? Tenetur odit commodi sapiente obcaecati.',
-      artUrl: 'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ef/Illustration_Quercus_robur0.jpg/170px-Illustration_Quercus_robur0.jpg'
+      artUrl:
+				'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ef/Illustration_Quercus_robur0.jpg/170px-Illustration_Quercus_robur0.jpg'
     },
     {
       name: 'Vtuber Fan #656556',
       twitter: '@vtuberfan#656556',
       text: 'Congrats! Big Fan!!!!',
-      artUrl: 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/45/Gebarsten_bolster_van_een_paardenkastanje_%28Aesculus%29_20-09-2020_%28d.j.b.%29_01.jpg/220px-Gebarsten_bolster_van_een_paardenkastanje_%28Aesculus%29_20-09-2020_%28d.j.b.%29_01.jpg'
+      artUrl:
+				'https://upload.wikimedia.org/wikipedia/commons/thumb/4/45/Gebarsten_bolster_van_een_paardenkastanje_%28Aesculus%29_20-09-2020_%28d.j.b.%29_01.jpg/220px-Gebarsten_bolster_van_een_paardenkastanje_%28Aesculus%29_20-09-2020_%28d.j.b.%29_01.jpg'
     }
   ]
 

--- a/src/pages/Elira.tsx
+++ b/src/pages/Elira.tsx
@@ -6,7 +6,7 @@ export default function Elira (): JSX.Element {
   const quote = 'Sheee-eeesh!'
   const info = 'Placeholder info for Elira!'
   const youtubeLink =
-		'https://www.youtube.com/channel/UCIeSUTOTkF9Hs7q3SGcO-Ow'
+    'https://www.youtube.com/channel/UCIeSUTOTkF9Hs7q3SGcO-Ow'
   const twitterLink = 'https://twitter.com/EliraPendora'
   const fanDiscordLink = ''
   const messages = [
@@ -62,63 +62,63 @@ export default function Elira (): JSX.Element {
       twitter: '@vtuberfan#1',
       text: 'Lorem ipsum dolor sit amet consectetur adipisicing elit. Ratione molestias consequuntur minima odit pariatur veritatis, recusandae, nam esse velit maxime et tempore voluptatum? Voluptatibus, veritatis? Tenetur odit commodi sapiente obcaecati.',
       artUrl:
-				'https://www.sciencenewsforstudents.org/wp-content/uploads/2020/04/1030_LL_trees-1028x579.png'
+        'https://www.sciencenewsforstudents.org/wp-content/uploads/2020/04/1030_LL_trees-1028x579.png'
     },
     {
       name: 'Vtuber Fan #2',
       twitter: '@vtuberfan#2',
       text: 'Congrats! Big Fan!!!!',
       artUrl:
-				'https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/Ash_Tree_-_geograph.org.uk_-_590710.jpg/220px-Ash_Tree_-_geograph.org.uk_-_590710.jpg'
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/Ash_Tree_-_geograph.org.uk_-_590710.jpg/220px-Ash_Tree_-_geograph.org.uk_-_590710.jpg'
     },
     {
       name: 'Vtuber Fan #3342',
       twitter: '@vtuberfan#3342',
       text: 'Congrats! Big Fan!!!!',
       artUrl:
-				'https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/Larix_decidua_Aletschwald.jpg/220px-Larix_decidua_Aletschwald.jpg'
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/Larix_decidua_Aletschwald.jpg/220px-Larix_decidua_Aletschwald.jpg'
     },
     {
       name: 'Vtuber Fan #4',
       twitter: '@vtuberfan#4',
       text: 'Congrats! Big Fan!!!!',
       artUrl:
-				'https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/Daintree_Rainforest_4.jpg/170px-Daintree_Rainforest_4.jpg'
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/Daintree_Rainforest_4.jpg/170px-Daintree_Rainforest_4.jpg'
     },
     {
       name: 'Vtuber Fan #543',
       twitter: '@vtuberfan#543',
       text: 'Congrats! Big Fan!!!!',
       artUrl:
-				'https://upload.wikimedia.org/wikipedia/commons/thumb/0/07/WisconsinScenery.jpg/220px-WisconsinScenery.jpg'
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/0/07/WisconsinScenery.jpg/220px-WisconsinScenery.jpg'
     },
     {
       name: 'Vtuber Fan #333',
       twitter: '@vtuberfan#333',
       text: 'Lorem ipsum dolor sit amet consectetur adipisicing elit. Ratione molestias consequuntur minima odit pariatur veritatis, recusandae, nam esse velit maxime et tempiente obcaecati.',
       artUrl:
-				'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7b/Bombax_LalBagh.JPG/220px-Bombax_LalBagh.JPG'
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7b/Bombax_LalBagh.JPG/220px-Bombax_LalBagh.JPG'
     },
     {
       name: 'Vtuber Fan #9879',
       twitter: '@vtuberfan#9879',
       text: 'Congrats! Big Fan!!!!',
       artUrl:
-				'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/Buk1.JPG/170px-Buk1.JPG'
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/Buk1.JPG/170px-Buk1.JPG'
     },
     {
       name: 'Vtuber Fan #56566',
       twitter: '@vtuberfan#56566',
       text: 'atione molestias consequuntur minima odit pariatur veritatis, recusandae, nam esse velit maxime et tempore voluptatum? Voluptatibus, veritatis? Tenetur odit commodi sapiente obcaecati.',
       artUrl:
-				'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ef/Illustration_Quercus_robur0.jpg/170px-Illustration_Quercus_robur0.jpg'
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ef/Illustration_Quercus_robur0.jpg/170px-Illustration_Quercus_robur0.jpg'
     },
     {
       name: 'Vtuber Fan #656556',
       twitter: '@vtuberfan#656556',
       text: 'Congrats! Big Fan!!!!',
       artUrl:
-				'https://upload.wikimedia.org/wikipedia/commons/thumb/4/45/Gebarsten_bolster_van_een_paardenkastanje_%28Aesculus%29_20-09-2020_%28d.j.b.%29_01.jpg/220px-Gebarsten_bolster_van_een_paardenkastanje_%28Aesculus%29_20-09-2020_%28d.j.b.%29_01.jpg'
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/4/45/Gebarsten_bolster_van_een_paardenkastanje_%28Aesculus%29_20-09-2020_%28d.j.b.%29_01.jpg/220px-Gebarsten_bolster_van_een_paardenkastanje_%28Aesculus%29_20-09-2020_%28d.j.b.%29_01.jpg'
     }
   ]
 

--- a/src/pages/Finana.tsx
+++ b/src/pages/Finana.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import TalentLayout from '../components/TalentLayout'
-import FinanaImage from '../assets/liver-image/finana-placeholder.png'
+import FinanaImage from '../assets/liver-image/finana-placeholder.png?format=png;avif;webp&imagetools&meta'
 
 function Finana (): JSX.Element {
   const name = 'Finana Ryugu'

--- a/src/pages/ImageExample.tsx
+++ b/src/pages/ImageExample.tsx
@@ -32,7 +32,9 @@ import Image from '../components/Image'
 export default function ImageExample (): JSX.Element {
   return (
     <>
+      {/* Works with normal images */}
       <Image src={normal} height='300px' />
+      {/* Works with imagetools too! */}
       <Image src={sheeshPogBased} height='300px' />
     </>
   )

--- a/src/pages/ImageExample.tsx
+++ b/src/pages/ImageExample.tsx
@@ -3,7 +3,7 @@
  * So, imagetools.
  * Normally, when you import an image, it'll just give you a url as a string.
  */
-// import normal from '../sheesh-pog-based.png'
+import normal from '../sheesh-pog-based.png'
 /*
  * You can just run the image through no problem just by specifying a format
  * as a query parameter to get some good compression
@@ -27,4 +27,13 @@
  */
 import sheeshPogBased from '../sheesh-pog-based.png?format=png;avif;webp&imagetools&meta'
 // The order is literally just to make this destructing easier, honestly
-const [fallback, ...sources] = sheeshPogBased
+import Image from '../components/Image'
+
+export default function ImageExample (): JSX.Element {
+  return (
+    <>
+      <Image src={normal} height='300px' />
+      <Image src={sheeshPogBased} height='300px' />
+    </>
+  )
+}

--- a/src/pages/ImageExample.tsx
+++ b/src/pages/ImageExample.tsx
@@ -1,0 +1,30 @@
+// TODO(abuffseagull) 2022-03-17: probably move this to a README
+/*
+ * So, imagetools.
+ * Normally, when you import an image, it'll just give you a url as a string.
+ */
+// import normal from '../sheesh-pog-based.png'
+/*
+ * You can just run the image through no problem just by specifying a format
+ * as a query parameter to get some good compression
+ */
+// import compressed from '../sheesh-pog-based.png?format=webp'
+/*
+ * You can also specify multiple formats, which will return an array of strings.
+ */
+// import multipleUrls from '../sheesh-pog-based.png?format=avif;webp;png'
+/*
+ * Now the really cool thing is that there's a `metadata` query param that will return
+ * extra info about each picture. Check the `images.d.ts` file for what it returns.
+ */
+// import multipleData from '../sheesh-pog-based.png?format=avif;webp;png&meta'
+/*
+ * Okay, to make typescript happy, you need to add `&imagetools` to the *end* of the url
+ * (but before meta, check the images.d.ts for how it finds the files).
+ * The actual imagetools plugin will ignore any query params it doesn't recognize, so
+ * we're abusing it to pattern match on typescript
+ * Also note the order of the formats. Fallback first, then in order of efficacy.
+ */
+import sheeshPogBased from '../sheesh-pog-based.png?format=png;avif;webp&imagetools&meta'
+// The order is literally just to make this destructing easier, honestly
+const [fallback, ...sources] = sheeshPogBased

--- a/src/pages/Pomu.tsx
+++ b/src/pages/Pomu.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import TalentLayout from '../components/TalentLayout'
-import PomuImage from '../assets/liver-image/pomu-placeholder.png'
+import PomuImage from '../assets/liver-image/pomu-placeholder.png?format=png;avif;webp&imagetools&meta'
 
 function Pomu (): JSX.Element {
   const quote = "I'm Pomu!"


### PR DESCRIPTION
- Added Image component that wraps around a `<picture>` element and handles imagetools metadata arrays. Also accepts a plain URL and returns a plain `<img>`. Should be a drop-in replacement for existing `<img>` tags.
- Used sheeshBasedPog to showcase this on main page