### PR TITLE
bump dependency version to patch vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "foobar",
+	"name": "lazulight-one-year-website",
 	"version": "0.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "foobar",
+			"name": "lazulight-one-year-website",
 			"version": "0.0.0",
 			"dependencies": {
 				"clsx": "^1.1.1",
@@ -3354,9 +3354,9 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
 			"dev": true
 		},
 		"node_modules/mkdirp-classic": {
@@ -7925,9 +7925,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
 			"dev": true
 		},
 		"mkdirp-classic": {


### PR DESCRIPTION
Bumped `minimist` from 1.2.5 to 1.2.6 to address that npm audit warning